### PR TITLE
Download RDBES raw data from SharePoint 

### DIFF
--- a/RegionalOverviews/data_preparation_RDBES/001_read_and_prepare_data_RDBES_CL_CE.R
+++ b/RegionalOverviews/data_preparation_RDBES/001_read_and_prepare_data_RDBES_CL_CE.R
@@ -1,6 +1,6 @@
 # based on the 001_read_and_prepare_data_rdb_2009_2021_CL_CE.r
 # script prepares datasets for further analysis
-
+setwd("Path to RCGs local repo")
 rm(list=ls())
 library(data.table)
 gc()
@@ -15,19 +15,19 @@ getwd()
 ################################################################################################################################################################
 ################################################################################################################################################################
 
-# ========================
-# set params
-# ======================== 
+## ========================
+## Set params
+## ======================== 
 
 target_region <- "RCG_NSEA" # RCG_BA, RCG_NA, RCG_NSEA
 year_start <- 2021
 year_end <- 2021
 time_tag<-format(Sys.time(), "%Y%m%d")
 
-# ====================== 
-# create directory structure
-# ====================== 
-#time_tag<-202006160931
+## ====================== 
+## Create directory structure
+## ====================== 
+
 dir_output_all<-paste("RegionalOverviews/data_RDBES/002_prepared/", time_tag, sep="")
 dir_output_rcg<-paste("RegionalOverviews/data_RDBES/002_prepared/", time_tag ,"/",target_region, sep="")
 
@@ -40,19 +40,25 @@ if (!dir.exists(dir_output_rcg)){
   dir.create(dir_output_rcg,recursive=TRUE, showWarnings=FALSE)
 }
 
-# ========================
-# downloads data from sharepoint
-# ======================== 
-
-# either download the data manually, or use the function below (some adjustment might be needed)
-# source("funs/func_download_data_from_sharepoint.r")
+## ========================
+## Downloads data from sharepoint
+## ======================== 
+## Here we obtain raw RDBES data. 
+#  The preferable choice is to use a function downloading the data from the SharePoint. Alternatively, data are to be manually downloaded. 
+source("RegionalOverviews/funs/func_download_data_from_sharepoint.r")
+download_data_from_sharepoint("https://community.ices.dk/ExternalSites/datacollection/Regional%20coordination%20meetings%202017/RCGIntersessionalWork/2022%20Meeting%20Documents/06.%20Data/Prepared_Data/RDBES_data/20240129", # Directory on SharePoint e.g. for a data version recent at moment of writing (should be modified to take the most recent)
+ filename_vector = paste0(target_region, ".zip"), 
+ dir_download_browser = "//storage-lk.slu.se/home$/erqu0001/Downloads", # Directory where browser downloads, e.g. on eros machine
+ dir_download_target = "Path to directory where data should be stored",  
+ unzip=TRUE
+ )
 
 # ========================
 # reads in data
 # ========================
 
 # reads aux_countries dataset
-aux_countries<-read.table("RegionalOverviews\\data\\aux_countries.txt", sep=",", header=T, colClasses="character", na.strings = "")
+aux_countries<-read.table("RegionalOverviews//data//aux_countries.txt", sep=",", header=T, colClasses="character", na.strings = "")
 
 # reads RDBES data
 RDBESdataPath = 'RegionalOverviews/data_RDBES/001_raw'
@@ -346,10 +352,10 @@ cl_rcg[is.na(CatchGroup),]
 file_info_cl<-file.info(file_cl)
 file_info_ce<-file.info(file_ce)
 
-save(cl_rcg, file_info_cl, file = paste(dir_output_rcg, paste("\\RDBES",target_region,"CL", year_start, year_end, "prepared",time_tag, sep="_"),".Rdata", sep=""))
-save(ce_rcg, file_info_ce, file = paste(dir_output_rcg, paste("\\RDBES",target_region,"CE", year_start, year_end, "prepared",time_tag, sep="_"),".Rdata", sep=""))
-save(cl, file_info_cl, file = paste(dir_output_all, paste("\\RDBES","All_Regions","CL", year_start, year_end, "prepared",time_tag, sep="_"),".Rdata", sep=""))
-save(ce, file_info_ce, file = paste(dir_output_all, paste("\\RDBES","All_Regions","CE", year_start, year_end, "prepared",time_tag, sep="_"),".Rdata", sep=""))	
+save(cl_rcg, file_info_cl, file = paste(dir_output_rcg, paste("//RDBES",target_region,"CL", year_start, year_end, "prepared",time_tag, sep="_"),".Rdata", sep=""))
+save(ce_rcg, file_info_ce, file = paste(dir_output_rcg, paste("//RDBES",target_region,"CE", year_start, year_end, "prepared",time_tag, sep="_"),".Rdata", sep=""))
+save(cl, file_info_cl, file = paste(dir_output_all, paste("//RDBES","All_Regions","CL", year_start, year_end, "prepared",time_tag, sep="_"),".Rdata", sep=""))
+save(ce, file_info_ce, file = paste(dir_output_all, paste("//RDBES","All_Regions","CE", year_start, year_end, "prepared",time_tag, sep="_"),".Rdata", sep=""))	
 
 
 

--- a/RegionalOverviews/funs/func_download_data_from_sharepoint.r
+++ b/RegionalOverviews/funs/func_download_data_from_sharepoint.r
@@ -1,95 +1,101 @@
- download_data_from_sharepoint<-function(sharepoint_address, filename_vector, dir_download_browser, dir_download_target, unzip = FALSE, delete_zip = FALSE)
-	{
-		# Nuno Prista, SLU, 2019 (project PanRegional SubGroup on Fisheries and Sampling Overviews)
-			# improvement of function download_data_cs4, developed by Nuno Prista, IPMA, 2015 (project fishPi)
-		
-		# Downloads data from e.g., ICES sharepoint into a dir_download_target in user's computer, unzips file upon request
-		
-		# Note: developed for Firefox: may (or may not) work on IE
-		
-		# Requires:
-			#sharepoint_address: url
-			#filename_vector: vector of filenames to download
-			#dir_download_browser: directory where firefox/ie downloads to
-			#dir_download_target = final directory where the data should be
-		
-		# Example:
-			#sharepoint_address <- "ADD_HERE_website_address"
-			#download_data_from_sharepoint (sharepoint_address, filename_vector = c("CL Landing 2009-2017.zip","CE Effort 2009-2017.zip"), dir_download_browser = "ADD_HERE_download_folder_adress", dir_download_target = getwd(), unzip=TRUE)
-
-		# Development notes
-			# 2019-04-03: fixed bug when downloads very fast (small files); simplified code
-			# 2019-04-13: fixed another bug when downloads very fast (small files); simplified code
-			# 2019-04-13: added option to delete_zip
-			# 2019-04-13: fixed bug in saving (was saving large files too fast, with size==0)
-
-			
-		# function for press key (from "https://stackoverflow.com/questions/15272916/how-to-wait-for-a-keypress-in-r")
-			readkey <- function()
-			{
-				cat ("Press [enter] to continue")
-				line <- readline()
-			}
-		
-		# Note: for some reason if *png or *txt firefox opens automatically in browser and does not prompt for saving...
-			if(sum(grepl(filename_vector, pat=".txt") | grepl(filename_vector, pat=".png"))>0) stop("Sorry, not yet developed for '.txt' and '.png' files")
-		
-		# opens connection
-			browseURL(sharepoint_address)
-		
-		# waits for user and password
-			print("Press key when sharepoint is open (you may need to login if you have not already)")
-			readkey()
-		
-		# loop to download files
-			for (filename in filename_vector)
-			{	
-			print(paste("Downloading",filename))
-
-			# prompts download file to dir_download_browser
-				browseURL(paste(sharepoint_address, filename, sep="/"))
+download_data_from_sharepoint<-function(sharepoint_address, filename_vector, dir_download_browser, dir_download_target, unzip = FALSE, delete_zip = FALSE){
+	# Nuno Prista, SLU, 2019 (project PanRegional SubGroup on Fisheries and Sampling Overviews)
+		# improvement of function download_data_cs4, developed by Nuno Prista, IPMA, 2015 (project fishPi)
 	
-			Sys.sleep(5); print(".waiting 5 secs for download to start...")
-		
-			# waits for file to be fully downloaded
-				files<-list.files(dir_download_browser);
-				#while(sum(grepl(files, pat=".part", fixed=T))>0 |  file.info(paste(dir_download_browser, filename, sep="/"))$size) 
-				while(
-					(grepl(filename, pat=".zip", fixed=T) & sum(grepl(files, pat=".part", fixed=T))>0) |  
-						(!is.na(file.size(paste(dir_download_browser, filename, sep="/"))) & file.size(paste(dir_download_browser, filename, sep="/"))==0)) 
-					{
-					Sys.sleep(2); print(".waiting 2 more secs for download to finish...")
-					files<-list.files(dir_download_browser)
-					}
-				print("Download finished!!")	
-				print(paste("final file_size:", file.size(paste(dir_download_browser, filename, sep="/"))))
-		# check
-			if(!file.exists(paste(dir_download_browser, filename, sep="/"))) stop ("file not downloaded!")
-			
-		# copies data from dir_download_browser to dir_download_target, removing from dir_download_browser
-			print(paste(".copying",filename,"from dir_download_browser to target.dir"))
-			file.copy(from = paste(dir_download_browser,filename,sep="/"), to = dir_download_target)
-			print(paste(".removing",filename,"from dir_download_browser"))
-			file.remove(paste(dir_download_browser, filename,sep="/"))
-		
-			print("Done!")		
+	# Downloads data from e.g., ICES sharepoint into a dir_download_target in user's computer, unzips file upon request
+	
+	# Note: developed for Firefox: may (or may not) work on IE
+	
+	# Requires:
+		#sharepoint_address: url
+		#filename_vector: vector of filenames to download
+		#dir_download_browser: directory where firefox/ie downloads to
+		#dir_download_target = final directory where the data should be
+	
+	# Example:
+		#sharepoint_address <- "ADD_HERE_website_address"
+		#download_data_from_sharepoint (sharepoint_address, filename_vector = c("CL Landing 2009-2017.zip","CE Effort 2009-2017.zip"), dir_download_browser = "ADD_HERE_download_folder_adress", dir_download_target = getwd(), unzip=TRUE)
 
-		if(unzip == TRUE)
-			{
-			if(grepl(filename, pat = ".zip", fixed=T))
-				{
-				Sys.sleep(2)
-				print(".unzipping...")
-	#			browser()
-				unzip(zipfile = paste(dir_download_target, filename, sep="/"), exdir=dir_download_target)
-				print("Done!")
-					if(delete_zip == TRUE)
-					{
-					print("Deleting zip...")
-					file.remove(paste(dir_download_target, filename,sep="/"))
-					print("Done!")
-					}
-				} else print("att: zip options ignored - file extension is not zip")
+	# Development notes
+		# 2019-04-03: fixed bug when downloads very fast (small files); simplified code
+		# 2019-04-13: fixed another bug when downloads very fast (small files); simplified code
+		# 2019-04-13: added option to delete_zip
+		# 2019-04-13: fixed bug in saving (was saving large files too fast, with size==0)
+
+		
+	# function for press key (from "https://stackoverflow.com/questions/15272916/how-to-wait-for-a-keypress-in-r")
+	readkey <- function()
+	{
+		cat ("Press [enter] to continue")
+		line <- readline()
+	}
+	
+	# Note: for some reason if *png or *txt firefox opens automatically in browser and does not prompt for saving...
+	if(sum(grepl(filename_vector, pat=".txt") | grepl(filename_vector, pat=".png"))>0) stop("Sorry, not yet developed for '.txt' and '.png' files")
+
+	# opens connection
+	browseURL(sharepoint_address)
+
+	# waits for user and password
+	print("Press key when sharepoint is open (you may need to login if you have not already)")
+	readkey()
+
+	# loop to download files
+	for (filename in filename_vector){	
+		print(paste("Downloading",filename))
+
+		# Check if file already exists at target location and, if so, delete it. (Otherwise it won´t unzip). 
+		if(any(list.files(dir_download_target) %in% filename)){ 
+			print(".pre-existing file with the same naming found at target directory, replacing...")
+			unlink(paste(dir_download_target, filename, sep = "/"),recursive=TRUE)
+			if(any(list.files(dir_download_target) %in% filename)){ # Checking that the file is no more there.
+				stop("Unable to overwrite existing file")
 			}
 		}
+
+		# prompts download file to dir_download_browser
+		browseURL(paste(sharepoint_address, filename, sep="/"))
+
+		Sys.sleep(5); print(".waiting 5 secs for download to start...")
+
+		# waits for file to be fully downloaded
+		files<-list.files(dir_download_browser);
+		#while(sum(grepl(files, pat=".part", fixed=T))>0 |  file.info(paste(dir_download_browser, filename, sep="/"))$size) 
+
+		while(
+			(grepl(filename, pat=".zip", fixed=T) & sum(grepl(files, pat=".part", fixed=T))>0) |  
+			(is.na(file.size(paste(dir_download_browser, filename, sep="/"))) & file.size(paste(dir_download_browser, paste0(filename, ".zip"), sep="/"))==0)){
+			Sys.sleep(2); print(".waiting 2 more secs for download to finish...")
+			files<-list.files(dir_download_browser)
+			}
+		print("Download finished!!")	
+		print(paste("final file_size:", file.size(paste(dir_download_browser, filename, sep="/"))))
+		# check
+		if(!file.exists(paste(dir_download_browser, filename, sep="/"))) stop ("file not downloaded!")
+	
+		# copies data from dir_download_browser to dir_download_target, removing from dir_download_browser
+		print(paste(".copying",filename,"from dir_download_browser to target.dir"))
+		file.copy(from = paste(dir_download_browser,filename,sep="/"), to = dir_download_target)
+		print(paste(".removing",filename,"from dir_download_browser"))
+		file.remove(paste(dir_download_browser, filename,sep="/"))
+
+		print("Done!")		
+
+		if(unzip == TRUE){
+			if(grepl(filename, pat = ".zip", fixed=T)){
+				Sys.sleep(2)
+				print(".unzipping...")
+				unzip(zipfile = paste(dir_download_target, filename, sep="/"), exdir=dir_download_target)
+				print("Done!")
+			} 
+
+		if(delete_zip == TRUE){
+			print("Deleting zip...")
+			file.remove(paste(dir_download_target, filename,sep="/"))
+			print("Done!")
+		}
+		} else {
+			print("att: zip options ignored - file extension is not zip")
+		}
 	}
+}

--- a/RegionalOverviews/funs/func_download_data_from_sharepoint.r
+++ b/RegionalOverviews/funs/func_download_data_from_sharepoint.r
@@ -1,7 +1,10 @@
 download_data_from_sharepoint<-function(sharepoint_address, filename_vector, dir_download_browser, dir_download_target, unzip = FALSE, delete_zip = FALSE){
-	# Nuno Prista, SLU, 2019 (project PanRegional SubGroup on Fisheries and Sampling Overviews)
+	# Author: Nuno Prista, SLU, 2019 (project PanRegional SubGroup on Fisheries and Sampling Overviews)
 		# improvement of function download_data_cs4, developed by Nuno Prista, IPMA, 2015 (project fishPi)
 	
+	# Contributor(s): 
+		# Eros Quesada, SLU, 2024
+
 	# Downloads data from e.g., ICES sharepoint into a dir_download_target in user's computer, unzips file upon request
 	
 	# Note: developed for Firefox: may (or may not) work on IE
@@ -21,8 +24,8 @@ download_data_from_sharepoint<-function(sharepoint_address, filename_vector, dir
 		# 2019-04-13: fixed another bug when downloads very fast (small files); simplified code
 		# 2019-04-13: added option to delete_zip
 		# 2019-04-13: fixed bug in saving (was saving large files too fast, with size==0)
+		# 2024-02-07: ensure overwriting when unzipping the file at the target directory 
 
-		
 	# function for press key (from "https://stackoverflow.com/questions/15272916/how-to-wait-for-a-keypress-in-r")
 	readkey <- function()
 	{


### PR DESCRIPTION
Developments on ensuring that the file downloaded by the existing function download_data_from_sharepoint  is replaced at target directory when already existent and default use of download_data_from_sharepoint function in the data preparation script, which may replace manual download of data prior to preparation. 

Given the actual structure of the RDBES data folder at the SharePoint (where data uploads are in a folder named with a date), ideally the function might list file from SharePoint webpage and select the most recent prior to download by default. 
For now, the user has to manually specify the folder. Thus a discussion may be useful on the following alternatives: 

a. changing the way we upload the raw version of data on SP (not by date, but overwriting the most recent version) 
b. developing further the function to list file and pick the most recent internally. 

